### PR TITLE
Adds optional seed kwarg for reproducibility

### DIFF
--- a/text2image.py
+++ b/text2image.py
@@ -26,6 +26,7 @@ parser.add_argument(
     default=512,
     help="image height, in pixels",
 )
+
 parser.add_argument(
     "--W",
     type=int,
@@ -39,9 +40,15 @@ parser.add_argument(
     default=7.5,
     help="unconditional guidance scale: eps = eps(x, empty) + scale * (eps(x, cond) - eps(x, empty))",
 )
+
 parser.add_argument(
     "--steps", type=int, default=50, help="number of ddim sampling steps"
 )
+
+parser.add_argument(
+    "--seed", type=int, help="optionally specify a seed integer for reproducible results"
+)
+
 args = parser.parse_args()
 
 generator = Text2Image(img_height=args.H, img_width=args.W, jit_compile=False)
@@ -51,6 +58,7 @@ img = generator.generate(
     unconditional_guidance_scale=args.scale,
     temperature=1,
     batch_size=1,
+    seed=args.seed
 )
 Image.fromarray(img[0]).save(args.output)
 print(f"saved at {args.output}")


### PR DESCRIPTION
@divamgupta 's Diffusion Bee UI suffered from not being able to leverage a seed to get reproducible results.

A large portion of prompt engineering/tweaking is being able to get the same base result and then iterate on the prompt. 

This PR simply adds an optional seed param - tested and works fine for getting reproducible results when given.

Thanks @fchollet and @divamgupta for the great work!